### PR TITLE
Workaround for invoking GatlingConfiguration.setUpForTest

### DIFF
--- a/http-cometd/src/test/scala/io/gatling/ConfigHook.scala
+++ b/http-cometd/src/test/scala/io/gatling/ConfigHook.scala
@@ -1,0 +1,8 @@
+package io.gatling
+
+import io.gatling.core.config.GatlingConfiguration
+
+object ConfigHook {
+	
+	def setUpForTest() = GatlingConfiguration.setUpForTest()
+}

--- a/http-cometd/src/test/scala/org/kaloz/gatling/http/action/cometd/CometDActorITest.scala
+++ b/http-cometd/src/test/scala/org/kaloz/gatling/http/action/cometd/CometDActorITest.scala
@@ -41,12 +41,11 @@ with MockitoSugar {
 
   private trait scope {
 
-    val gatlingPropertyBuilder = new GatlingPropertiesBuilder
-    GatlingConfiguration.setUp(gatlingPropertyBuilder.build)
+    io.gatling.ConfigHook.setUpForTest()
+
     GatlingActorSystem.start
-    val runMessage = mock[RunMessage]
+    val runMessage = RunMessage("simulationClassName", "simulationId", io.gatling.core.util.TimeHelper.nowMillis, "Run")
     val replyTo = TestProbe()
-    when(runMessage.runDescription).thenReturn("Run")
     DataWriter.init(runMessage, Seq(), replyTo.ref)
 
     val wsTx = mock[WsTx]
@@ -64,9 +63,7 @@ with MockitoSugar {
     val cometDActor = TestActorRef(new CometDActor("name"))
     val listener = TestActorRef(new Listener)
     cometDActor ! OnOpen(wsTx, webSocket, 1000)
-
   }
-
 }
 
 class Listener extends Actor {

--- a/http-cometd/src/test/scala/org/kaloz/gatling/http/action/cometd/PubSubProccessorActorITest.scala
+++ b/http-cometd/src/test/scala/org/kaloz/gatling/http/action/cometd/PubSubProccessorActorITest.scala
@@ -52,6 +52,8 @@ with BeforeAndAfterAll {
 
   private trait scope {
 
+    io.gatling.ConfigHook.setUpForTest()
+
     import org.kaloz.gatling.json.JsonMarshallableImplicits._
 
     val pubSubProccessorActor = TestActorRef(new PubSubProccessorActorStub)


### PR DESCRIPTION
Your serialization issue causing core dumps (caused by mocks) happens because you use incomplete mocks reporting is not disabled.

Gatling has a special method for setting up config for tests and disabling reporting, but it's private for now (see https://github.com/gatling/gatling/issues/2326). This workaround introduces a public entry point in io.gatling package.
