### PR TITLE
Allow ext on subscribe messages and change format of messages

### DIFF
--- a/http-cometd/src/main/scala/org/kaloz/gatling/http/cometd/CometDMessages.scala
+++ b/http-cometd/src/main/scala/org/kaloz/gatling/http/cometd/CometDMessages.scala
@@ -12,7 +12,7 @@ object CometDMessages {
 
   case class Disconnect(channel: String = "/meta/disconnect", clientId: String = "${cometDClientId}", id: String = "${cometDMessageId}")
 
-  case class Subscribe(channel: String = "/meta/subscribe", clientId: String = "${cometDClientId}", subscription: String, id: String = "${cometDMessageId}")
+  case class Subscribe(channel: String = "/meta/subscribe", clientId: String = "${cometDClientId}", subscription: String, id: String = "${cometDMessageId}", ext: Option[Any] = None)
 
   case class Unsubscribe(channel: String = "/meta/unsubscribe", clientId: String = "${cometDClientId}", subscription: String, id: String = "${cometDMessageId}")
 

--- a/http-cometd/src/main/scala/org/kaloz/gatling/http/request/builder/cometd/CometD.scala
+++ b/http-cometd/src/main/scala/org/kaloz/gatling/http/request/builder/cometd/CometD.scala
@@ -23,7 +23,7 @@ class CometD(val requestName: Expression[String], val cometDName: String = Comet
 
   def connect(connect: Connect = Connect()) = new CometDConnectActionBuilder(requestName, cometDName, connect)
 
-  def subscribe(subscription: String, ext: Option[Any] = None)) = new CometDSubscribeActionBuilderStep1(requestName, cometDName, Subscribe(subscription = subscription, ext = ext))
+  def subscribe(subscription: String, ext: Option[Any] = None) = new CometDSubscribeActionBuilderStep1(requestName, cometDName, Subscribe(subscription = subscription, ext = ext))
 
   def unsubscribe(subscription: String) = new CometDUnsubscribeActionBuilder(requestName, cometDName, Unsubscribe(subscription = subscription))
 

--- a/http-cometd/src/main/scala/org/kaloz/gatling/http/request/builder/cometd/CometD.scala
+++ b/http-cometd/src/main/scala/org/kaloz/gatling/http/request/builder/cometd/CometD.scala
@@ -23,7 +23,7 @@ class CometD(val requestName: Expression[String], val cometDName: String = Comet
 
   def connect(connect: Connect = Connect()) = new CometDConnectActionBuilder(requestName, cometDName, connect)
 
-  def subscribe(subscription: String) = new CometDSubscribeActionBuilderStep1(requestName, cometDName, Subscribe(subscription = subscription))
+  def subscribe(subscription: String, ext: Option[Any] = None)) = new CometDSubscribeActionBuilderStep1(requestName, cometDName, Subscribe(subscription = subscription, ext = ext))
 
   def unsubscribe(subscription: String) = new CometDUnsubscribeActionBuilder(requestName, cometDName, Unsubscribe(subscription = subscription))
 

--- a/http-cometd/src/main/scala/org/kaloz/gatling/json/JsonUtil.scala
+++ b/http-cometd/src/main/scala/org/kaloz/gatling/json/JsonUtil.scala
@@ -18,7 +18,7 @@ object JsonUtil {
   mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
 
   def toJson(value: Any): String = {
-    mapper.writeValueAsString(value)
+    mapper.writeValueAsString(Array(value))
   }
 
   def fromJson[T: Manifest](json: String): T = {


### PR DESCRIPTION
Hi,

I opened this pull requests to propose two changes in the gatling-cometd library:
1. In our application, we have an extension that adds some additional data to subscribe messages. I extended the classes to allow ext fields in subscribe messages.
2. Our CometD server expects all messages to be an array, otherwise it fails to process the message. I couldn't find some official doc about it, but the example messages in the CometD documentation always show arrays, see https://docs.cometd.org/current/reference/#_messages 
